### PR TITLE
Fix openCamera

### DIFF
--- a/app/src/main/java/com/example/vcam/HookMain.java
+++ b/app/src/main/java/com/example/vcam/HookMain.java
@@ -139,7 +139,7 @@ public class HookMain implements IXposedHookLoadPackage {
         }
 
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             XposedHelpers.findAndHookMethod("android.hardware.camera2.CameraManager", lpparam.classLoader, "openCamera", String.class,java.util.concurrent.Executor.class , CameraDevice.StateCallback.class, new XC_MethodHook() {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) throws Throwable {


### PR DESCRIPTION
openCamera(String, Executor, CameraDevice.StateCallback)是Android P开始才有的接口。